### PR TITLE
Update tests

### DIFF
--- a/src/test/java/yarr/ParserTest.java
+++ b/src/test/java/yarr/ParserTest.java
@@ -8,8 +8,22 @@ import org.junit.jupiter.api.Test;
 
 public class ParserTest {
     @Test
-    public void parseDate_correctFormat_success() {
+    public void parseDate_correctFormat_format1_success() {
         String input1 = "09/02/2024 1800";
+        LocalDateTime expectedDate = LocalDateTime.of(2024, 2, 9, 18, 00);
+        LocalDateTime testDate = Parser.parseDate(input1);
+        assertEquals(testDate, expectedDate);
+    }
+    @Test
+    public void parseDate_correctFormat_format2_success() {
+        String input1 = "09-02-2024 1800";
+        LocalDateTime expectedDate = LocalDateTime.of(2024, 2, 9, 18, 00);
+        LocalDateTime testDate = Parser.parseDate(input1);
+        assertEquals(testDate, expectedDate);
+    }
+    @Test
+    public void parseDate_correctFormat_format3_success() {
+        String input1 = "09022024 1800";
         LocalDateTime expectedDate = LocalDateTime.of(2024, 2, 9, 18, 00);
         LocalDateTime testDate = Parser.parseDate(input1);
         assertEquals(testDate, expectedDate);

--- a/src/test/java/yarr/task/EventTest.java
+++ b/src/test/java/yarr/task/EventTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
+import yarr.Parser;
 
 public class EventTest {
     @Test
@@ -14,5 +15,13 @@ public class EventTest {
         Event event = new Event("Test Event", testFrom, testTo);
         String expectedData = "E | 0 | Test Event | 09/02/2024 1800 | 10/02/2024 0900";
         assertEquals(event.getData(), expectedData);
+    }
+    @Test
+    public void toString_success() {
+        LocalDateTime testFrom = LocalDateTime.of(2024, 2, 9, 18, 00);
+        LocalDateTime testTo = LocalDateTime.of(2024, 2, 10, 9, 00);
+        Event event = new Event("Test Event", testFrom, testTo);
+        String expectedData = "[E][ ] Test Event (from: Feb 09 2024 06:00 PM to: Feb 10 2024 09:00 AM)";
+        assertEquals(event.toString(), expectedData);
     }
 }


### PR DESCRIPTION
Parser and Event tests are out of date. Parser class's parseDate in particular does not account for friendlier syntax date formats.

Tests should account for alternative date syntax.

Adding two methods for addition alternative syntax allows us to cover all cases where parseDate is expected to correctly produce LocalDateTime from input.